### PR TITLE
Adds container info field in logstash configuration

### DIFF
--- a/External-Service (ELK)/configs/logstash/pipeline/logstash.conf
+++ b/External-Service (ELK)/configs/logstash/pipeline/logstash.conf
@@ -5,8 +5,30 @@ input {
 }
 
 filter {
+  json {
+    source => "message"
+    target => "parsed_json"
+  }
+
+  grok {
+    match => {
+      "[message]" => '%{DATA:message}image\":\"[^:]+:(?<image_version>[^\"]+)\"%{DATA}'
+    }
+    tag_on_failure => ["_image-version-extract-failure", "_log-error"]
+  }
+  
   mutate {
-    add_tag => "my_custom_tag"
+    add_field => {
+      "[container_info][service]" => "%{[parsed_json][docker][name]}"
+      "[container_info][id]" => "%{[parsed_json][docker][id]}"
+      "[container_info][type]" => "your_type"
+      "[container_info][version]" => "%{[image_version]}"
+      "message" => "%{[parsed_json][message]}"
+    }
+
+    remove_field => ["message"]
+    remove_field => ["parsed_json"]
+    remove_field => ["image_version"]
   }
 }
 

--- a/External-Service (ELK)/docker-compose.yml
+++ b/External-Service (ELK)/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     ports:
     - '9600:9600'
     environment:
-      LS_JAVA_OPTS: "-Xmx256m -Xms256m"    
+      LS_JAVA_OPTS: "-Xmx256m -Xms256m"  
     networks:
       - fablo_network_202308300640_basic
 


### PR DESCRIPTION
Example of processed log:

```
{
  "@timestamp": "2023-09-16T13:27:35.944Z",
  "host": "logspout.fablo_network_202308300640_basic",
  "port": 44342,
  "@version": "1",
  "container_info": {
    "version": "latest",
    "type": "your_type",
    "id": "ebc40755d847a707380dc06df25986e096e822472d516db7401183f81ec3b434",
    "service": "/orderer.example.com"
  }
}
```

Here, we have extracted the image's version (in above example: "latest") with following pattern: `'%{DATA:message}image\":\"[^:]+:(?<image_version>[^\"]+)\"%{DATA}'` 