### PR TITLE
feat: add container type dynamically

### DIFF
--- a/External-Service (ELK)/configs/logstash/pipeline/input.conf
+++ b/External-Service (ELK)/configs/logstash/pipeline/input.conf
@@ -23,19 +23,29 @@ filter {
     add_field => {
       "[container_info][service]" => "%{[parsed_json][docker][name]}"
       "[container_info][id]" => "%{[parsed_json][docker][id]}"
-      "[container_info][type]" => "your_type"
       "[container_info][version]" => "%{[image_version]}"
       "message" => "%{[parsed_json][message]}"
     }
     remove_field => ["message", "parsed_json"]
   }
+  
+  if [container_info][service] =~ /peer.+/ {
+    mutate {
+    add_field => { "[container_info][type]" => "peer" }
+    }
+  }
+  else if [container_info][service] =~ /orderer.+/ {
+    mutate {
+    add_field => { "[container_info][type]" => "orderer" }
+    }
+  }
 }
 
 output {
-  if [container_info][service] =~ /peer.+/ {
+  if [container_info][type] == "peer" {
     pipeline { send_to => peerLogs }
   }
-  else if [container_info][service] =~ /orderer.+/ {
+  else if [container_info][type] == "orderer" {
     pipeline { send_to => ordererLogs }
   }
   else {


### PR DESCRIPTION
Resulting processed logs with dynamic field "type":

```
{
  "ordererTestField": "ordererTestFieldValue",
  "port": 35838,
  "@version": "1",
  "host": "logspout.fablo_network_202308300640_basic",
  "container_info": {
    "service": "/orderer.example.com",
    "type": "orderer",
    "version": "latest",
    "id": "ebc40755d847a707380dc06df25986e096e822472d516db7401183f81ec3b434"
  },
  "@timestamp": "2023-09-19T03:16:45.268Z",
  "image_version": "latest"
}
```
