### PR TITLE
Add filter for orderer pipeline

### DIFF
--- a/External-Service (ELK)/configs/logstash/pipeline/input.conf
+++ b/External-Service (ELK)/configs/logstash/pipeline/input.conf
@@ -18,7 +18,6 @@ filter {
     tag_on_failure => ["_image-version-extract-failure", "_log-error"]
   }
 
-  # Add containers info to the top level object called 'container_info'
   mutate {
     add_field => {
       "[container_info][service]" => "%{[parsed_json][docker][name]}"
@@ -30,6 +29,12 @@ filter {
     remove_field => ["parsed_json", "message"]
   }
   
+  ruby {
+    code => '
+        event.set("fabric_log_message", event.get("fabric_log_message").gsub(/\x1B\[[^m]*m/, ""))
+    '
+  }
+
   if [container_info][image_name] =~ /^hyperledger\/fabric-peer/ {
     mutate {
       add_field => { "[container_info][type]" => "peer" }

--- a/External-Service (ELK)/configs/logstash/pipeline/input.conf
+++ b/External-Service (ELK)/configs/logstash/pipeline/input.conf
@@ -25,9 +25,9 @@ filter {
       "[container_info][id]" => "%{[parsed_json][docker][id]}"
       "[container_info][version]" => "%{[image_version]}"
       "[container_info][image_name]" => "%{[parsed_json][docker][image]}"
-      "message" => "%{[parsed_json][message]}"
+      "fabric_log_message" => "%{[parsed_json][message]}"
     }
-    remove_field => ["message", "parsed_json"]
+    remove_field => ["parsed_json", "message"]
   }
   
   if [container_info][image_name] =~ /^hyperledger\/fabric-peer/ {
@@ -35,7 +35,7 @@ filter {
       add_field => { "[container_info][type]" => "peer" }
     }
   }
-  else if [container_info][service] =~ /^hyperledger\/fabric-orderer/ {
+  else if [container_info][image_name] =~ /^hyperledger\/fabric-orderer/ {
     mutate {
       add_field => { "[container_info][type]" => "orderer" }
     }

--- a/External-Service (ELK)/configs/logstash/pipeline/input.conf
+++ b/External-Service (ELK)/configs/logstash/pipeline/input.conf
@@ -29,6 +29,7 @@ filter {
     remove_field => ["parsed_json", "message"]
   }
   
+  # Remove color code like: \u001B
   ruby {
     code => '
         event.set("fabric_log_message", event.get("fabric_log_message").gsub(/\x1B\[[^m]*m/, ""))

--- a/External-Service (ELK)/configs/logstash/pipeline/orderer.conf
+++ b/External-Service (ELK)/configs/logstash/pipeline/orderer.conf
@@ -5,17 +5,21 @@ filter {
     add_field => {
       "ordererTestField" => "ordererTestFieldValue"
     }
-   }
+  }
 
-   # Extracting block creation details
-   grok {
-      match => {
-         "fabric_log_message" => "Created block \[(?<block_number>\d+)\], there are %{NUMBER:blocks_in_flight:int} blocks in flight channel=%{WORD:channel_name} node=%{NUMBER:node_number:int}"
-      }
-      add_tag => ["blockinfo"]
-      tag_on_failure => ["_orderer-blockinfo-extract-failure", "_log-error"]
-   }
-
+  # Extracting block creation and writing details
+  grok {
+    match => {
+      "fabric_log_message" => [
+         # Extracting: block_number, blocks_in_flight, channel_name, node_number
+        "Created block \[(?<block_number>\d+)\], there are %{NUMBER:blocks_in_flight:int} blocks in flight channel=%{WORD:channel_name} node=%{NUMBER:node_number:int}",
+        # Extracting: block_number, raft_index, channel_name, node_number
+        "Writing block \[%{NUMBER:block_number:int}\] \(Raft index: %{NUMBER:raft_index:int}\) to ledger channel=%{WORD:channel_name} node=%{NUMBER:node_number:int}"
+      ]
+    }
+    add_tag => ["blockinfo"]
+    tag_on_failure => ["_orderer-blockinfo-extract-failure", "_log-error"]
+  }
 }
 
 output {

--- a/External-Service (ELK)/configs/logstash/pipeline/orderer.conf
+++ b/External-Service (ELK)/configs/logstash/pipeline/orderer.conf
@@ -12,9 +12,9 @@ filter {
     match => {
       "fabric_log_message" => [
          # Extracting: block_number, blocks_in_flight, channel_name, node_number
-        "Created block \[(?<block_number>\d+)\], there are %{NUMBER:blocks_in_flight:int} blocks in flight channel=%{WORD:channel_name} node=%{NUMBER:node_number:int}",
+        "%{TIMESTAMP_ISO8601:block_timestamp} .* Created block \[(?<block_number>\d+)\], there are %{NUMBER:blocks_in_flight:int} blocks in flight channel=%{WORD:channel_name} node=%{NUMBER:node_number:int}",
         # Extracting: block_number, raft_index, channel_name, node_number
-        "Writing block \[%{NUMBER:block_number:int}\] \(Raft index: %{NUMBER:raft_index:int}\) to ledger channel=%{WORD:channel_name} node=%{NUMBER:node_number:int}"
+        "%{TIMESTAMP_ISO8601:block_timestamp} .* Writing block \[%{NUMBER:block_number:int}\] \(Raft index: %{NUMBER:raft_index:int}\) to ledger channel=%{WORD:channel_name} node=%{NUMBER:node_number:int}"
       ]
     }
     add_tag => ["blockinfo"]

--- a/External-Service (ELK)/configs/logstash/pipeline/orderer.conf
+++ b/External-Service (ELK)/configs/logstash/pipeline/orderer.conf
@@ -6,6 +6,16 @@ filter {
       "ordererTestField" => "ordererTestFieldValue"
     }
    }
+
+   # Extracting block creation details
+   grok {
+      match => {
+         "fabric_log_message" => "Created block \[(?<block_number>\d+)\], there are %{NUMBER:blocks_in_flight:int} blocks in flight channel=%{WORD:channel_name} node=%{NUMBER:node_number:int}"
+      }
+      add_tag => ["blockinfo"]
+      tag_on_failure => ["_orderer-blockinfo-extract-failure", "_log-error"]
+   }
+
 }
 
 output {

--- a/External-Service (ELK)/configs/logstash/pipeline/orderer.conf
+++ b/External-Service (ELK)/configs/logstash/pipeline/orderer.conf
@@ -2,10 +2,10 @@ input { pipeline { address => ordererLogs } }
 
 filter {
    mutate {
-    add_field => {
-      "ordererTestField" => "ordererTestFieldValue"
-    }
-  }
+      add_field => {
+         "ordererTestField" => "ordererTestFieldValue"
+      }
+   }
 
   # Extracting block creation and writing details
   grok {
@@ -19,7 +19,39 @@ filter {
     }
     add_tag => ["blockinfo"]
     tag_on_failure => ["_orderer-blockinfo-extract-failure", "_log-error"]
-  }
+   }
+
+  if "_orderer-blockinfo-extract-failure" not in [tags] {
+
+      # Add fields common to all types of log messages
+      mutate {
+         add_field => {
+            "[block_info][block_number]" => "%{block_number}"
+            "[block_info][channel_name]" => "%{channel_name}"
+            "[block_info][node_number]" => "%{node_number}"
+            "[block_info][block_timestamp]" => "%{block_timestamp}"
+         }
+      }
+      
+      #  Add additional fields based on type of log message
+      if "Created block" in [fabric_log_message] {
+         mutate {
+            add_field => {
+               "[block_info][blocks_in_flight]" => "%{blocks_in_flight}"
+            }
+         }
+      } else if "Writing block" in [fabric_log_message] {
+         mutate {
+            add_field => {
+               "[block_info][raft_index]" => "%{raft_index}"
+            }
+         }
+      }
+
+      mutate {
+         remove_field => ["block_number", "blocks_in_flight", "raft_index", "channel_name", "node_number", "block_timestamp"]
+      }
+   }
 }
 
 output {


### PR DESCRIPTION
I have added 2 matching filters, specifically for "Creating block" and "Writing block".

Now the resulting log is as follows:
("ordererTestField": "ordererTestFieldValue" is just for testing, will be removed letter)

```
{
  "tags": ["blockinfo"],
  "container_info": {
    "service": "/orderer.example.com",
    "id": "ebc40755d847a707380dc06df25986e096e822472d516db7401183f81ec3b434",
    "image_name": "hyperledger/fabric-orderer:latest",
    "version": "latest",
    "type": "orderer"
  },
  "image_version": "latest",
  "fabric_log_message": "2023-09-29 18:03:36.761 UTC 0721 INFO [orderer.consensus.etcdraft] writeBlock -> Writing block [421] (Raft index: 423) to ledger channel=mychannel node=1",
  "ordererTestField": "ordererTestFieldValue",
  "@timestamp": "2023-09-29T18:03:36.762Z",
  "@version": "1",
  "block_info": {
    "raft_index": "423",
    "block_timestamp": "2023-09-29 18:03:36.761",
    "node_number": "1",
    "channel_name": "mychannel",
    "block_number": "421"
  },
  "port": 55178,
  "host": "logspout.fablo_network_202308300640_basic"
}

```